### PR TITLE
Use hex hashes rather than raw ByteString

### DIFF
--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -6,6 +6,10 @@
 module Lib where
 
 import           Control.Monad.Trans
+import           Crypto.Hash                    ( Digest
+                                                , SHA256
+                                                , digestFromByteString
+                                                )
 import           Crypto.Hash.SHA256
 import           Data.Aeson
 import           Data.Binary
@@ -35,8 +39,15 @@ instance Out Block
 epoch :: IO Int
 epoch = round `fmap` getPOSIXTime
 
+fromJust :: Maybe a -> a
+fromJust Nothing = error "Hash error"
+fromJust (Just x) = x
+
+sha256 :: String -> Maybe (Digest SHA256)
+sha256 = digestFromByteString . hash . pack
+
 hashString :: String -> String
-hashString = unpack . hash . pack
+hashString = show . fromJust . sha256
 
 calculateBlockHash :: Block -> String
 calculateBlockHash (Block i p t b _)  = hashString $ concat [show i, p, show t, b]

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -39,13 +39,18 @@ instance Out Block
 epoch :: IO Int
 epoch = round `fmap` getPOSIXTime
 
+-- used to unwrap hex digests that come
+-- from the sha256 function below
 fromJust :: Maybe a -> a
 fromJust Nothing = error "Hash error"
 fromJust (Just x) = x
 
+-- hashes a string and returns a hex digest
 sha256 :: String -> Maybe (Digest SHA256)
 sha256 = digestFromByteString . hash . pack
 
+-- abstracted hash function that takes a string
+-- to hash and returns a hex string
 hashString :: String -> String
 hashString = show . fromJust . sha256
 

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -13,7 +13,7 @@ import           Crypto.Hash                    ( Digest
 import           Crypto.Hash.SHA256
 import           Data.Aeson
 import           Data.Binary
-import           Data.ByteString.Char8          (pack, unpack)
+import           Data.ByteString.Char8          (pack)
 import           Data.Time.Clock.POSIX
 import           GHC.Generics
 import           Text.PrettyPrint.GenericPretty
@@ -39,12 +39,6 @@ instance Out Block
 epoch :: IO Int
 epoch = round `fmap` getPOSIXTime
 
--- used to unwrap hex digests that come
--- from the sha256 function below
-fromJust :: Maybe a -> a
-fromJust Nothing = error "Hash error"
-fromJust (Just x) = x
-
 -- hashes a string and returns a hex digest
 sha256 :: String -> Maybe (Digest SHA256)
 sha256 = digestFromByteString . hash . pack
@@ -52,7 +46,7 @@ sha256 = digestFromByteString . hash . pack
 -- abstracted hash function that takes a string
 -- to hash and returns a hex string
 hashString :: String -> String
-hashString = show . fromJust . sha256
+hashString = maybe (error "Something went wrong generating a hash") show . sha256
 
 calculateBlockHash :: Block -> String
 calculateBlockHash (Block i p t b _)  = hashString $ concat [show i, p, show t, b]


### PR DESCRIPTION
Hey Avi, 18nleung from HN here -

In order to implement a rudimentary POW system (hash must be less than certain value) the hashes need to be expressed in hex notation at first.

I'm new to Haskell but I found a way to get a String hex digest out of the Crypto.Hash.SHA256 hash function rather than a raw ByteString - please let me know how my code looks and whether this can be merged!

Nathan