### PR TITLE
`replaceChain` set newChain, if it is valid and longer.

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -85,7 +85,7 @@ mineBlock stringData = do
 replaceChain :: MonadIO m => IORef [Block] -> [Block] -> m ()
 replaceChain chainRef newChain = do
   currentChain <- liftIO $ readIORef chainRef
-  if not $ isValidChain newChain || (length currentChain >= length newChain)
+  if (not . isValidChain) newChain || length currentChain >= length newChain
     then liftDebug $ "chain is not valid for updating!: " ++ show newChain
     else do
       setChain <- liftIO $ atomicModifyIORef' chainRef $ const (newChain, newChain)


### PR DESCRIPTION
Hey Avi. This program interest me. 
When I read `replaceChain`, I thought the condition is not suitable for your comment: "-- if this chain is valid and longer than what we have, update it.". The condition is `not $ isValiidChain newChain || (length currentChain >= length newChain)` is evaled as `(not (isValiidChain newChain)) && (not (length currentChain >= length newChain))`. Are not you intending `(not (isValiidChain newChain)) || (length currentChain >= length newChain)`?