### PR TITLE
add rudimentary proof of work

### DIFF
--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -11,6 +11,7 @@ import           Crypto.Hash                    ( Digest
                                                 , digestFromByteString
                                                 )
 import           Crypto.Hash.SHA256
+import           Text.Read                      (readMaybe)
 import           Data.Aeson
 import           Data.Binary
 import           Data.ByteString.Char8          (pack)
@@ -23,6 +24,7 @@ data Block = Block { index        :: Int
                    , previousHash :: String
                    , timestamp    :: Int
                    , blockData    :: String
+                   , nonce        :: Int
                    , blockHash    :: String
                    } deriving (Show, Eq, Generic)
 
@@ -46,22 +48,51 @@ sha256 = digestFromByteString . hash . pack
 -- abstracted hash function that takes a string
 -- to hash and returns a hex string
 hashString :: String -> String
-hashString = maybe (error "Something went wrong generating a hash") show . sha256
+hashString =
+  maybe (error "Something went wrong generating a hash") show . sha256
 
 calculateBlockHash :: Block -> String
-calculateBlockHash (Block i p t b _)  = hashString $ concat [show i, p, show t, b]
+calculateBlockHash (Block i p t b n _)  =
+  hashString $ concat [show i, p, show t, b, show n]
 
 -- returns a copy of the block with the hash set
 addHashToBlock :: Block -> Block
 addHashToBlock block = block { blockHash = calculateBlockHash block }
+
+-- Rudimentary proof-of-work: ensures that a block hash
+-- is less than a certain value (i.e. contains a certain
+-- amount of leading zeroes)
+-- In our case, it's 4 leading zeroes. We're using the Integer type
+-- since the current target is higher than the max for Int
+difficultyTarget :: Integer
+difficultyTarget =
+  0x0000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+-- checks whether the provided block hash satisfies
+-- our PoW requirement
+satisfiesPow :: String -> Bool
+satisfiesPow blockHash = maybe
+  (error $ "Something is wrong with the provided hash: " ++ blockHash)
+  (< difficultyTarget)
+  (readMaybe ("0x" ++ blockHash) :: Maybe Integer)
+
+-- Recursively finds a nonce that satisfies the difficulty target
+-- If our blockHash already satisfies the PoW, return the current nonce
+-- If not, increment the nonce and try again
+findNonce :: Block -> Int
+findNonce block = do
+  let blockHash     = calculateBlockHash block
+      currentNonce  = nonce block
+  if satisfiesPow blockHash
+    then currentNonce
+    else findNonce $ block { nonce = currentNonce + 1 }
 
 -- a hardcoded initial block, we need this to make sure all
 -- nodes have the same starting point, so we have a hard coded
 -- frame of reference to detect validity
 initialBlock :: Block
 initialBlock = do
-  let block = Block 0 "0" 0 "initial data" ""
-  block { blockHash = calculateBlockHash block }
+  let block = Block 0 "0" 0 "initial data" 0 ""
+  addHashToBlock $ block { nonce = findNonce block }
 
 -- a new block is valid if its index is 1 higher, its
 -- previous hash points to our last block, and its hash is computed
@@ -70,7 +101,8 @@ isValidNewBlock :: Block -> Block -> Bool
 isValidNewBlock prev next
   | index prev + 1 == index next &&
     blockHash prev == previousHash next &&
-    blockHash next == calculateBlockHash next = True
+    blockHash next == calculateBlockHash next &&
+    satisfiesPow (blockHash next) = True
   | otherwise = False
 
 -- a chain is valid if it starts with our hardcoded initial
@@ -88,9 +120,11 @@ isValidChain chain = case chain of
 mineBlockFrom :: (MonadIO m) => Block -> String -> m Block
 mineBlockFrom lastBlock stringData = do
   time <- liftIO epoch
-  return . addHashToBlock $ Block { index        = index lastBlock + 1
-                                  , previousHash = blockHash lastBlock
-                                  , timestamp    = time
-                                  , blockData    = stringData
-                                  , blockHash    = "will be changed"
-                                  }
+  let block = Block { index        = index lastBlock + 1
+                    , previousHash = blockHash lastBlock
+                    , timestamp    = time
+                    , blockData    = stringData
+                    , nonce        = 0
+                    , blockHash    = "will be changed"
+                    }
+  return . addHashToBlock $ block { nonce = findNonce block }


### PR DESCRIPTION
# Overview

I added some code for a basic proof-of-work system - please let me know what you think! (also whether my Haskell is idiomatic enough - as a mostly JS developer this is very different from anything I've done before).

Here's a summary of my changes:

* added a nonce field to the `Block` data type
* added the nonce field to the function which calculates the block hash
* added a difficulty target (if block has 4 leading zeroes in its hash, then on average it should take (16^4 = 65536) attempts to get a valid hash
* added functions to:
  * check whether a hash satisfies the difficulty requirement
  * find a valid nonce for a given block
* added the PoW check to the block validity check (a block is invalid if its hash does not satisfy our difficulty target)
* edited the initial block generator so the initial block also has a valid nonce and hash

Here's an example of what the `/chain` endpoint would look like with these additions:

```
[Block {index = 0,
        previousHash = "0",
        timestamp = 0,
        blockData = "initial data",
        nonce = 62859,
        blockHash = "0000a76be26ea918bee1b6379d75aca69b1d4e185f151fdeed8877beddba028c"},
 Block {index = 1,
        previousHash = "0000a76be26ea918bee1b6379d75aca69b1d4e185f151fdeed8877beddba028c",
        timestamp = 1497719968,
        blockData = "ayo",
        nonce = 93070,
        blockHash = "000034221278560e831ae596366d578c7f1b2ec4bdb225650c8781a31db760ed"}]
```

# Further thoughts

* Perhaps we could add an option when `POST`ing a block to `/block` to specify the difficulty? So users can choose what target they want their block hash to hit.
* There's an edge case in which a user could hit the maximum of Haskell's `Int` type (2^29 - 1 = 536870911). I'm not exactly sure about the mathematics behind knowing when this should become a problem but when the difficulty target is 8 leading zeroes (16^8) then on average it should take more attempts (i.e. a greater nonce value) than 2^29 - 1 to get a valid hash. In that case, we'd need to increment another field of the block (with Bitcoin, miners usually increment the timestamp and try again)